### PR TITLE
Update PayPal Tax Provider to support Shipping Tax

### DIFF
--- a/Provider/TaxProvider.php
+++ b/Provider/TaxProvider.php
@@ -56,10 +56,21 @@ class TaxProvider
     public function getTax($entity)
     {
         try {
+            /**
+             * NOTE: The code below has been modified to resolve an issue where no
+             * tax was passed to PayPal, causing the total amount to be invalid
+             * eg $11 items (inc tax) + $100 shipping (ex tax) = $121 total (inc tax)
+             * If the Products already include Tax, we need to obtain the Shipping Tax
+             * and include that
+             *
+             * This code *may* be deprecated once the Tax improvements in Oro 3.1.0-LTS are merged
+             */
             if ($this->taxationSettingsProvider->isProductPricesIncludeTax()) {
-                return null;
+                // Product Prices already include Tax, so we only want the Shipping Tax
+                return $this->taxManager->loadTax($entity)->getShipping()->getTaxAmount();
             }
 
+            // Return the Total Tax (Products + Shipping)
             return $this->taxManager->loadTax($entity)->getTotal()->getTaxAmount();
         } catch (\Throwable $exception) {
             $this->logger->info(


### PR DESCRIPTION
**Scenario**
1. Product Prices include Tax
1. Shipping Prices exclude Tax

**Sample Data**
* Tax Rate: 10%
* Product Total: $11.00 (inc Tax)
* Shipping Total: $100.00 (ex Tax)
* Expected Total: $121.00 (inc Tax)

**Before Change**
* Product Total: $11.00
* Shipping Total: $100.00
* Taxes: $0.00
* Sum of Items: $111.00 ($11 + $100)
* Passed Total $121.00
* PayPal Response: **Error: Transaction amount details (subtotal, tax, shipping) must add up to specified amount total**

**After Change**
* Product Total: $11.00
* Shipping Total: $100.00
* Taxes: $10.00 (from shipping)
* Sum of Items: $121.00 ($11 + $100 + $10)
* Passed Total $121.00
* PayPal Response: **Successful**