### PR TITLE
Resolve 3.1.0 Twig compatibility issue

### DIFF
--- a/Resources/views/layouts/default/imports/oro_payment_method_options/layout.html.twig
+++ b/Resources/views/layouts/default/imports/oro_payment_method_options/layout.html.twig
@@ -1,6 +1,6 @@
 {% block _payment_methods_paypal_express_widget %}
     <div class="{{ class_prefix }}__form__payment-methods">
-        <img src="{% image '@OroPayPalExpressBundle/Resources/public/default/images/pp-express-checkout-method.png' %}{{ asset_url }}{% endimage %}">
+        <img src="{{ asset('bundles/oropaypalexpress/default/images/pp-express-checkout-method.png') }}">
         <div>{{ 'oro.paypal_express.checkout.redirect_to_paypal'|trans|nl2br }}</div>
     </div>
 {% endblock %}


### PR DESCRIPTION
Assetic has been removed in 3.1.0, removed 'image' tag as it's no longer available.