### PR TITLE
Block updates to Payment Transactions once they have been marked inac…

### DIFF
--- a/EventListener/PayPalExpressRedirectListener.php
+++ b/EventListener/PayPalExpressRedirectListener.php
@@ -45,6 +45,10 @@ class PayPalExpressRedirectListener
             return;
         }
 
+        if (!$paymentTransaction->isActive()) {
+            return;
+        }
+
         $paymentTransaction
             ->setSuccessful(false)
             ->setActive(false);
@@ -72,6 +76,10 @@ class PayPalExpressRedirectListener
         if (!$paymentTransaction || !isset($eventData['paymentId'], $eventData['PayerID'], $eventData['token']) ||
             $eventData['paymentId'] !== $paymentTransaction->getReference()
         ) {
+            return;
+        }
+
+        if (!$paymentTransaction->isActive()) {
             return;
         }
 


### PR DESCRIPTION
…tive. This prevents a user from clicking 'Cancel' in another tab and having the original transaction marked as failed.